### PR TITLE
Implement sidebar item selection

### DIFF
--- a/form-dashboard/app/dashboard/layout.tsx
+++ b/form-dashboard/app/dashboard/layout.tsx
@@ -2,6 +2,7 @@ import { cookies } from "next/headers"
 
 import { AppSidebar } from "@/components/app-sidebar"
 import { SidebarProvider } from "@/components/ui/sidebar"
+import { DashboardProvider } from "@/components/dashboard-context"
 
 // Define um tipo para o objeto do usuário para clareza
 type User = {
@@ -28,9 +29,11 @@ export default function DashboardLayout({
   const user: User = userCookie ? JSON.parse(userCookie.value) : defaultUser
 
   return (
-    <SidebarProvider>
-      <AppSidebar user={user} />
-      {children}
-    </SidebarProvider>
+    <DashboardProvider>
+      <SidebarProvider>
+        <AppSidebar user={user} />
+        {children}
+      </SidebarProvider>
+    </DashboardProvider>
   )
 }

--- a/form-dashboard/app/dashboard/page.tsx
+++ b/form-dashboard/app/dashboard/page.tsx
@@ -8,8 +8,10 @@ import {
 } from "@/components/ui/breadcrumb"
 import { Separator } from "@/components/ui/separator"
 import { SidebarInset, SidebarTrigger } from "@/components/ui/sidebar"
+import { useDashboard } from "@/components/dashboard-context"
 
 export default function Page() {
+  const { selectedItem } = useDashboard()
   return (
     <SidebarInset>
         <header className="flex h-16 shrink-0 items-center gap-2">
@@ -21,12 +23,14 @@ export default function Page() {
             />
             <Breadcrumb>
               <BreadcrumbList>
-                {/* <BreadcrumbItem className="hidden md:block">
-                  <BreadcrumbLink href="#">
-                    Building Your Application
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator className="hidden md:block" /> */}
+                {selectedItem && (
+                  <>
+                    <BreadcrumbItem className="hidden md:block">
+                      <BreadcrumbLink href="#">{selectedItem}</BreadcrumbLink>
+                    </BreadcrumbItem>
+                    <BreadcrumbSeparator className="hidden md:block" />
+                  </>
+                )}
                 <BreadcrumbItem>
                   <BreadcrumbPage>Dashboard</BreadcrumbPage>
                 </BreadcrumbItem>
@@ -35,12 +39,20 @@ export default function Page() {
           </div>
         </header>
         <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-          <div className="grid auto-rows-min gap-4 md:grid-cols-3">
-            <div className="bg-muted/50 aspect-video rounded-xl" />
-            <div className="bg-muted/50 aspect-video rounded-xl" />
-            <div className="bg-muted/50 aspect-video rounded-xl" />
-          </div>
-          <div className="bg-muted/50 min-h-[100vh] flex-1 rounded-xl md:min-h-min" />
+          {selectedItem ? (
+            <div className="bg-muted/50 min-h-[100vh] flex items-center justify-center rounded-xl md:min-h-min">
+              <h2 className="text-xl font-bold">{selectedItem}</h2>
+            </div>
+          ) : (
+            <>
+              <div className="grid auto-rows-min gap-4 md:grid-cols-3">
+                <div className="bg-muted/50 aspect-video rounded-xl" />
+                <div className="bg-muted/50 aspect-video rounded-xl" />
+                <div className="bg-muted/50 aspect-video rounded-xl" />
+              </div>
+              <div className="bg-muted/50 min-h-[100vh] flex-1 rounded-xl md:min-h-min" />
+            </>
+          )}
         </div>
       </SidebarInset>
   )

--- a/form-dashboard/components/app-sidebar.tsx
+++ b/form-dashboard/components/app-sidebar.tsx
@@ -26,6 +26,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
+import { useDashboard } from "@/components/dashboard-context"
 // import Separator from "@/components/ui/separator"
 const navMain = [
     {
@@ -155,6 +156,7 @@ export function AppSidebar({
   user,
   ...props
 }: { user: User } & React.ComponentProps<typeof Sidebar>) {
+  const { selectedItem, setSelectedItem } = useDashboard()
   return (
     <Sidebar variant="inset" {...props}>
       {/* <SidebarHeader>
@@ -175,7 +177,11 @@ export function AppSidebar({
         </SidebarMenu>
       </SidebarHeader> */}
       <SidebarContent>
-        <NavMain items={navMain} />
+        <NavMain
+          items={navMain}
+          onSelect={setSelectedItem}
+          activeItem={selectedItem}
+        />
         {/* <NavProjects projects={projects} /> */}
         {/* <NavSecondary items={navSecondary} className="mt-auto" /> */}
       </SidebarContent>

--- a/form-dashboard/components/dashboard-context.tsx
+++ b/form-dashboard/components/dashboard-context.tsx
@@ -1,0 +1,26 @@
+"use client"
+import React from "react"
+
+interface DashboardContextProps {
+  selectedItem: string | null
+  setSelectedItem: (item: string | null) => void
+}
+
+const DashboardContext = React.createContext<DashboardContextProps | undefined>(undefined)
+
+export function DashboardProvider({ children }: { children: React.ReactNode }) {
+  const [selectedItem, setSelectedItem] = React.useState<string | null>(null)
+  return (
+    <DashboardContext.Provider value={{ selectedItem, setSelectedItem }}>
+      {children}
+    </DashboardContext.Provider>
+  )
+}
+
+export function useDashboard() {
+  const context = React.useContext(DashboardContext)
+  if (!context) {
+    throw new Error("useDashboard must be used within DashboardProvider")
+  }
+  return context
+}

--- a/form-dashboard/components/nav-main.tsx
+++ b/form-dashboard/components/nav-main.tsx
@@ -21,6 +21,8 @@ import {
 
 export function NavMain({
   items,
+  onSelect,
+  activeItem,
 }: {
   items: {
     title: string
@@ -32,6 +34,8 @@ export function NavMain({
       url: string
     }[]
   }[]
+  onSelect?: (title: string) => void
+  activeItem?: string | null
 }) {
   return (
     <SidebarGroup>
@@ -40,11 +44,13 @@ export function NavMain({
         {items.map((item) => (
           <Collapsible key={item.title} asChild defaultOpen={item.isActive}>
             <SidebarMenuItem>
-              <SidebarMenuButton asChild tooltip={item.title}>
-                <a href={item.url}>
-                  <item.icon />
-                  <span>{item.title}</span>
-                </a>
+              <SidebarMenuButton
+                tooltip={item.title}
+                isActive={activeItem === item.title}
+                onClick={() => onSelect?.(item.title)}
+              >
+                <item.icon />
+                <span>{item.title}</span>
               </SidebarMenuButton>
               {item.items?.length ? (
                 <>
@@ -58,10 +64,11 @@ export function NavMain({
                     <SidebarMenuSub>
                       {item.items?.map((subItem) => (
                         <SidebarMenuSubItem key={subItem.title}>
-                          <SidebarMenuSubButton asChild>
-                            <a href={subItem.url}>
-                              <span>{subItem.title}</span>
-                            </a>
+                          <SidebarMenuSubButton
+                            onClick={() => onSelect?.(subItem.title)}
+                            isActive={activeItem === subItem.title}
+                          >
+                            <span>{subItem.title}</span>
                           </SidebarMenuSubButton>
                         </SidebarMenuSubItem>
                       ))}


### PR DESCRIPTION
## Summary
- add `DashboardProvider` for sharing selected navigation item
- update `AppSidebar` and `NavMain` to use the provider
- show selected item in `SidebarInset` header breadcrumb
- display placeholder screen for selected item

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run build` *(fails: blocked fetching fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_688a6131aaa08327a19a5be9276f08f4