### PR TITLE
refactor: handle access token refresh on client

### DIFF
--- a/form-dashboard/app/api/login/route.ts
+++ b/form-dashboard/app/api/login/route.ts
@@ -84,7 +84,7 @@ export async function POST(request: Request) {
     (await
       // O accessToken precisa ser acessível pelo middleware e também pelo JavaScript
       // do lado do cliente para chamadas de API. Por isso, NÃO é httpOnly.
-      cookies()).set("access_token", accessToken, { ...cookieOptions, maxAge: 60 * 15, httpOnly: false }); // 15 minutos
+      cookies()).set("access_token", accessToken, { ...cookieOptions, httpOnly: false });
     // O refreshToken é usado para obter um  novo accessToken sem que o usuário
     // precise fazer login novamente. Ele tem uma vida longa e é armazenado
     // de forma segura como um cookie httpOnly.

--- a/form-dashboard/lib/tokenManager.ts
+++ b/form-dashboard/lib/tokenManager.ts
@@ -1,0 +1,69 @@
+function getCookie(name: string): string | undefined {
+  if (typeof document === 'undefined') {
+    return undefined;
+  }
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop()?.split(';').shift();
+}
+
+function setCookie(name: string, value: string) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  document.cookie = `${name}=${value}; path=/`;
+}
+
+function isTokenExpiring(token: string, thresholdMs = 10 * 60 * 1000) {
+  try {
+    const payloadBase64 = token.split('.')[1];
+    const decodedJson = atob(payloadBase64);
+    const decoded = JSON.parse(decodedJson);
+    const exp = decoded.exp * 1000;
+    const timeRemaining = exp - Date.now();
+    return timeRemaining <= thresholdMs;
+  } catch (error) {
+    console.error('[TokenManager] Failed to decode token', error);
+    return true;
+  }
+}
+
+export async function refreshAccessTokenIfNeeded() {
+  const refreshToken = getCookie('refresh_token');
+  let accessToken = getCookie('access_token');
+
+  if (!refreshToken) {
+    console.log('[TokenManager] No refresh token available.');
+    return;
+  }
+
+  if (!accessToken || isTokenExpiring(accessToken)) {
+    console.log('[TokenManager] Access token missing or expiring. Refreshing...');
+    try {
+      const response = await fetch('/api/auth/refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token: refreshToken }),
+      });
+
+      if (!response.ok) {
+        console.error('[TokenManager] Failed to refresh token:', response.status);
+        return;
+      }
+
+      const data = await response.json();
+      if (!data.access_token) {
+        console.error('[TokenManager] No access token in refresh response');
+        return;
+      }
+
+      accessToken = data.access_token;
+      setCookie('access_token', accessToken);
+      console.log('[TokenManager] Token refreshed successfully.');
+    } catch (error) {
+      console.error('[TokenManager] Error refreshing token:', error);
+    }
+  }
+}
+
+export { getCookie };


### PR DESCRIPTION
## Summary
- centralize token refresh logic in new helper
- use helper from client fetch wrapper to refresh tokens proactively
- simplify middleware to only handle routing
- remove manual cookie expiration to align with backend token lifetimes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68c4167afa708327ac72ad9311879ed0